### PR TITLE
Improvement of the use of GPG passphrase when publish the lib to Maven central with the use of an env var.

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -43,9 +43,9 @@ jobs:
 
       - name: Publish to Maven Central
         env:
-          GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
         run: |
           mvn clean deploy -P release \
             -DskipTests \
-            -Dgpg.passphrase=$GPG_PASSPHRASE \
-            --batch-mode --no-transfer-progress
+            --batch-mode  \
+            --no-transfer-progress


### PR DESCRIPTION
Improvement of the use of GPG passphrase when publish the lib to Maven central with the use of an env var.